### PR TITLE
Feature/add change return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1]
+
+- Change return types
+
 ## [1.1.0]
 
 - Updated for Drupal 10

--- a/drupal_psr6_cache.module
+++ b/drupal_psr6_cache.module
@@ -10,7 +10,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 /**
  * Implements hook_help().
  */
-function drupal_psr6_cache_help($route_name, RouteMatchInterface $route_match) {
+function drupal_psr6_cache_help(string $route_name, RouteMatchInterface $route_match): string {
   switch ($route_name) {
     // Main module help for the drupal_psr6_cache module.
     case 'help.page.drupal_psr6_cache':

--- a/drupal_psr6_cache.module
+++ b/drupal_psr6_cache.module
@@ -11,14 +11,17 @@ use Drupal\Core\Routing\RouteMatchInterface;
  * Implements hook_help().
  */
 function drupal_psr6_cache_help(string $route_name, RouteMatchInterface $route_match): string {
+  $output = '';
+
   switch ($route_name) {
     // Main module help for the drupal_psr6_cache module.
     case 'help.page.drupal_psr6_cache':
-      $output = '';
+
       $output .= '<h3>' . t('About') . '</h3>';
       $output .= '<p>' . t('PSR-6: Caching Interface for Drupal 8+') . '</p>';
-      return $output;
 
     default:
   }
+
+  return $output;
 }

--- a/drupal_psr6_cache.module
+++ b/drupal_psr6_cache.module
@@ -12,7 +12,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 function drupal_psr6_cache_help(string $route_name, RouteMatchInterface $route_match): string {
   $output = '';
-
   switch ($route_name) {
     // Main module help for the drupal_psr6_cache module.
     case 'help.page.drupal_psr6_cache':

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,8 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  // @phpstan-ignore-next-line
-  private ?float $expiry;
+  private ?float $expiry; // @phpstan-ignore-line
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -13,21 +13,21 @@ class CacheItem implements CacheItemInterface {
    *
    * @var string
    */
-  private $key;
+  private string $key;
 
   /**
    * The value.
    *
    * @var mixed
    */
-  private $value;
+  private mixed $value;
 
   /**
    * The is hit.
    *
    * @var bool
    */
-  private $isHit;
+  private bool $isHit;
 
   /**
    * The expiry.
@@ -46,7 +46,7 @@ class CacheItem implements CacheItemInterface {
    * @param bool $isHit
    *   The is hit.
    */
-  public function __construct(string $key, $data, bool $isHit) {
+  public function __construct(string $key, mixed $data, bool $isHit) {
     $this->key   = $key;
     $this->value = $data;
     $this->isHit = $isHit;
@@ -62,7 +62,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function get() {
+  public function get(): mixed {
     return $this->value;
   }
 
@@ -89,7 +89,7 @@ class CacheItem implements CacheItemInterface {
     if ($expiration === NULL) {
       $this->expiry = NULL;
     }
-    elseif ($expiration instanceof DateTimeInterface) {
+    elseif ($expiration instanceof \DateTimeInterface) {
       $this->expiry = (float) $expiration->format('U.u');
     }
     else {
@@ -109,8 +109,8 @@ class CacheItem implements CacheItemInterface {
     if ($time === NULL) {
       $this->expiry = NULL;
     }
-    elseif ($time instanceof DateInterval) {
-      $this->expiry = microtime(TRUE) + DateTime::createFromFormat('U', 0)->add($time)->format('U.u');
+    elseif ($time instanceof \DateInterval) {
+      $this->expiry = microtime(TRUE) + (float) \DateTime::createFromFormat('U', 0)->add($time)->format('U.u');
     }
     elseif (is_int($time)) {
       $this->expiry = $time + microtime(TRUE);

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -86,7 +86,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function expiresAt($expiration): static {
+  public function expiresAt(DateTimeInterface|null $expiration): static {
     if ($expiration === NULL) {
       $this->expiry = NULL;
     }
@@ -100,7 +100,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function expiresAfter($time): static {
+  public function expiresAfter(DateInterval|int|null $time): static {
     if ($time === NULL) {
       $this->expiry = NULL;
     }

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  private $expiry;
+  private ?float $expiry;
 
   /**
    * CacheItem constructor.
@@ -89,14 +89,8 @@ class CacheItem implements CacheItemInterface {
     if ($expiration === NULL) {
       $this->expiry = NULL;
     }
-    elseif ($expiration instanceof \DateTimeInterface) {
-      $this->expiry = (float) $expiration->format('U.u');
-    }
     else {
-      throw new \RuntimeException(sprintf(
-        'Expected $expiration to be an instance of DateTimeInterface or null, got %s',
-        is_object($expiration) ? get_class($expiration) : gettype($expiration)
-      ));
+      $this->expiry = (float) $expiration->format('U.u');
     }
 
     return $this;
@@ -110,16 +104,10 @@ class CacheItem implements CacheItemInterface {
       $this->expiry = NULL;
     }
     elseif ($time instanceof \DateInterval) {
-      $this->expiry = microtime(TRUE) + (float) \DateTime::createFromFormat('U', 0)->add($time)->format('U.u');
+      $this->expiry = microtime(TRUE) + (float) \DateTime::createFromFormat('U', '0')->add($time)->format('U.u');
     }
-    elseif (is_int($time)) {
+    elseif {
       $this->expiry = $time + microtime(TRUE);
-    }
-    else {
-      throw new \RuntimeException(sprintf(
-        'Expected $time to be either an integer, an instance of DateInterval or null, got %s',
-        is_object($time) ? get_class($time) : gettype($time)
-      ));
     }
 
     return $this;

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  private ?float $expiry; // @phpstan-ignore-line
+  private ?float $expiry;
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -106,7 +106,7 @@ class CacheItem implements CacheItemInterface {
     elseif ($time instanceof \DateInterval) {
       $this->expiry = microtime(TRUE) + (float) \DateTime::createFromFormat('U', '0')->add($time)->format('U.u');
     }
-    elseif {
+    else {
       $this->expiry = $time + microtime(TRUE);
     }
 

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  public ?float $expiry;
+  private ?float $expiry;
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  private ?float $expiry;
+  public ?float $expiry;
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -76,7 +76,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function set($value): self {
+  public function set($value): static {
     $this->value = $value;
 
     return $this;
@@ -85,7 +85,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function expiresAt($expiration): self {
+  public function expiresAt($expiration): static {
     if ($expiration === NULL) {
       $this->expiry = NULL;
     }
@@ -105,7 +105,7 @@ class CacheItem implements CacheItemInterface {
   /**
    * {@inheritdoc}
    */
-  public function expiresAfter($time): self {
+  public function expiresAfter($time): static {
     if ($time === NULL) {
       $this->expiry = NULL;
     }

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,8 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  private ?float $expiry; /** @phpstan-ignore-line */
+  /** @phpstan-ignore-next-line */
+  private ?float $expiry;
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  /** @phpstan-ignore-next-line */
+  // @phpstan-ignore-next-line
   private ?float $expiry;
 
   /**

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -34,7 +34,7 @@ class CacheItem implements CacheItemInterface {
    *
    * @var float|null
    */
-  private ?float $expiry;
+  private ?float $expiry; /** @phpstan-ignore-line */
 
   /**
    * CacheItem constructor.

--- a/src/Cache/CacheItemPool.php
+++ b/src/Cache/CacheItemPool.php
@@ -57,8 +57,8 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * {@inheritdoc}
    *
-   * @return
-   *   array<int, CacheItemInterface>
+   * @return array<int, CacheItemInterface>
+   *   A list of items.
    */
   public function getItems(array $keys = []): array {
     return array_map([$this, 'getItem'], $keys);

--- a/src/Cache/CacheItemPool.php
+++ b/src/Cache/CacheItemPool.php
@@ -57,7 +57,7 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * {@inheritdoc}
    */
-  public function getItems(array $keys = []): iterable {
+  public function getItems(array $keys = []): array {
     return array_map([$this, 'getItem'], $keys);
   }
 
@@ -72,7 +72,7 @@ class CacheItemPool implements CacheItemPoolInterface {
    * {@inheritdoc}
    */
   public function clear(): bool {
-    $this->cacheTagsInvalidator->invalidateTags(static::TAGS);
+    $this->cacheTagsInvalidator->invalidateTags(self::TAGS);
 
     return TRUE;
   }
@@ -103,7 +103,7 @@ class CacheItemPool implements CacheItemPoolInterface {
       $this->getCid($item->getKey()),
       $item->get(),
       Cache::PERMANENT,
-      static::TAGS
+      self::TAGS
     );
 
     return TRUE;
@@ -133,7 +133,7 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * Get cache id.
    */
-  private function getCid(string $key) {
+  private function getCid(string $key): string {
     return 'drupal_psr6_cache:' . $key;
   }
 

--- a/src/Cache/CacheItemPool.php
+++ b/src/Cache/CacheItemPool.php
@@ -57,7 +57,8 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * {@inheritdoc}
    *
-   * @return array<int, CacheItemInterface>
+   * @return
+   *   array<int, CacheItemInterface>
    */
   public function getItems(array $keys = []): array {
     return array_map([$this, 'getItem'], $keys);

--- a/src/Cache/CacheItemPool.php
+++ b/src/Cache/CacheItemPool.php
@@ -56,6 +56,8 @@ class CacheItemPool implements CacheItemPoolInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * @return array<int, CacheItemInterface>
    */
   public function getItems(array $keys = []): array {
     return array_map([$this, 'getItem'], $keys);

--- a/src/Cache/CacheItemPool.php
+++ b/src/Cache/CacheItemPool.php
@@ -17,23 +17,23 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * Deferred cache items.
    *
-   * @var \Drupal\Core\Cache\CacheItemInterface[]
+   * @var \Psr\Cache\CacheItemInterface[]
    */
-  protected $deferred = [];
+  protected array $deferred = [];
 
   /**
    * The cache.
    *
    * @var \Drupal\Core\Cache\CacheBackendInterface
    */
-  private $cache;
+  private CacheBackendInterface $cache;
 
   /**
    * The cache tags invalidator.
    *
    * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
    */
-  private $cacheTagsInvalidator;
+  private CacheTagsInvalidatorInterface $cacheTagsInvalidator;
 
   /**
    * Constructor.
@@ -46,7 +46,7 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * {@inheritdoc}
    */
-  public function getItem($key) {
+  public function getItem($key): CacheItemInterface {
     $value = $this->cache->get($this->getCid($key));
 
     return $value !== FALSE
@@ -57,65 +57,77 @@ class CacheItemPool implements CacheItemPoolInterface {
   /**
    * {@inheritdoc}
    */
-  public function getItems(array $keys = []) {
+  public function getItems(array $keys = []): iterable {
     return array_map([$this, 'getItem'], $keys);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function hasItem($key) {
+  public function hasItem($key): bool {
     return $this->getItem($key)->isHit();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clear() {
+  public function clear(): bool {
     $this->cacheTagsInvalidator->invalidateTags(static::TAGS);
+
+    return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function deleteItem($key) {
+  public function deleteItem($key): bool {
     $this->cache->delete($this->getCid($key));
+
+    return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function deleteItems(array $keys) {
-    return array_map([$this, 'deleteItem'], $keys);
+  public function deleteItems(array $keys): bool {
+    array_map([$this, 'deleteItem'], $keys);
+
+    return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function save(CacheItemInterface $item) {
+  public function save(CacheItemInterface $item): bool {
     $this->cache->set(
       $this->getCid($item->getKey()),
       $item->get(),
       Cache::PERMANENT,
       static::TAGS
     );
+
+    return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function saveDeferred(CacheItemInterface $item) {
+  public function saveDeferred(CacheItemInterface $item): bool {
     $hash = spl_object_hash($item);
     $this->deferred[$hash] = $item;
+
+    return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function commit() {
+  public function commit(): bool {
     foreach ($this->deferred as $deferred) {
       $this->save($deferred);
     }
+
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
Change return types, and add a few.

I'm unsure if $expiry; in CacheItem.php should be made public or removed. It's  never used within the class but all that the two expire methods do is set it. So what gives???